### PR TITLE
Fixed major bug in version checks

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -146,20 +146,20 @@ $array = $array | Where {$_.DisplayName -ne $null} | Sort-Object -Property Displ
     
 $ProblematicPrograms = @()
 $ProblematicPrograms += New-Object PSObject -Property @{ProgramName="AMD Chipset Software";RecommendedVersion='6.02.07.2300';Installed=$false;Notes="Outdated versions are known to cause issues."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Cepstral SwiftTalker";RecommendedVersion='0.0';Installed=$false;Notes="Known to cause crashes in the past."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="ESET";RecommendedVersion='0.0';Installed=$false;Notes="Known to cause crashes. Please disable or add Exclusions for the .des files in the tools folder." }
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Hamachi";RecommendedVersion='0.0';Installed=$false;Notes="Will prevent connectivity. Recommend uninstall or disable IN DEVICE MANAGER"}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="iCue";RecommendedVersion='0.0';Installed=$false;Notes="Outdated versions are known to cause issues."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Cepstral SwiftTalker";RecommendedVersion='100.100';Installed=$false;Notes="Known to cause crashes in the past."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="ESET";RecommendedVersion='100.100';Installed=$false;Notes="Known to cause crashes. Please disable or add Exclusions for the .des files in the tools folder." }
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Hamachi";RecommendedVersion='100.100';Installed=$false;Notes="Will prevent connectivity. Recommend uninstall or disable IN DEVICE MANAGER"}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="iCue";RecommendedVersion='100.100';Installed=$false;Notes="Outdated versions are known to cause issues."}
 $ProblematicPrograms += New-Object PSObject -Property @{ProgramName="MSI Afterburner";RecommendedVersion='4.6.5';Installed=$false;Notes="Outdated versions are known to cause issues."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Outplayed";RecommendedVersion='0.0';Installed=$false;Notes="Known to cause stuttering & VRAM leaks. Disable Outplayed Autoclipping or disable/uninstall completely."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Overwolf";RecommendedVersion='0.0'; Installed=$false;Notes="Known to cause stuttering & VRAM leaks. Disable Outplayed Autoclipping or disable/uninstall completely."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Radmin";RecommendedVersion='0.0';Installed=$false;Notes="Will cause network issues. Recommend uninstalling or disabling in DEVICE MANAGER."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Razer Cortex";RecommendedVersion='0.0';Installed=$false;Notes="Known to cause CPU Threading issues & possibly other issues. Recommend disabling/uninstalling."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Outplayed";RecommendedVersion='100.100';Installed=$false;Notes="Known to cause stuttering & VRAM leaks. Disable Outplayed Autoclipping or disable/uninstall completely."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Overwolf";RecommendedVersion='100.100'; Installed=$false;Notes="Known to cause stuttering & VRAM leaks. Disable Outplayed Autoclipping or disable/uninstall completely."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Radmin";RecommendedVersion='100.100';Installed=$false;Notes="Will cause network issues. Recommend uninstalling or disabling in DEVICE MANAGER."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Razer Cortex";RecommendedVersion='100.100';Installed=$false;Notes="Known to cause CPU Threading issues & possibly other issues. Recommend disabling/uninstalling."}
 $ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Ryzen Master";RecommendedVersion='2.13.0.2908';Installed=$false;Notes="Known to cause RAM leaks & general issues. Recommend uninstalling."}
 $ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Samsung Magician";RecommendedVersion='8.1';Installed=$false;Notes="Outdated versions are known to completely prevent connectivity."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Surfshark";RecommendedVersion='0.0';Installed=$false;Notes="Will prevent connectivity. Recommend uninstall or disable IN DEVICE MANAGER"}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Wargaming.net Game Center";Installed=$false;RecommendedVersion='0.0';Notes="Reported to cause issues."}
-$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Webroot";Installed=$false;RecommendedVersion='0.0';Notes="Causes low FPS. Uninstall or launch HD2 & THEN shutdown Webroot."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Surfshark";RecommendedVersion='100.100';Installed=$false;Notes="Will prevent connectivity. Recommend uninstall or disable IN DEVICE MANAGER"}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Wargaming.net Game Center";Installed=$false;RecommendedVersion='100.100';Notes="Reported to cause issues."}
+$ProblematicPrograms += New-Object PSObject -Property @{ProgramName="Webroot";Installed=$false;RecommendedVersion='100.100';Notes="Causes low FPS. Uninstall or launch HD2 & THEN shutdown Webroot."}
 
 $bool = $false
 Write-Host "`nChecking for installed problematic programs..." -ForegroundColor Cyan


### PR DESCRIPTION
Programs with version numbers set to 0.0 were not detected at all. For now, set version numbers to 100.100 for programs that should not be installed.