### PR TITLE
AM5 workaround for CPU-Z

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -1149,9 +1149,14 @@ Function Test-MemoryChannels {
     # Define the pattern to search for
     $DDR4pattern = "^Channels\t+[2-8]\s+x\s+64-bit$"
     $DDR5pattern = "^Channels\t+[4-8]\s+x\s+32-bit$"
+    $AM5DDR5pattern = "^Channels\t+[2-8]\s+x\s+32-bit$"
     $DualChannelPattern = "^Channels\t+s+Dual$"
     $TripleChannelPattern = "^Channels\t+\s+Triple$"
     $QuadChannelPattern = "^Channels\t+\s+Quad$"
+    If ($global:HardwareInfoText -match "^\s*Package\s*Socket AM5 (LGA1718)" -and $global:HardwareInfoText -match $AM5DDR5pattern ) {
+        $global:Tests.MultiChannelMemory.TestPassed = $true
+        Return
+    }
     If ($global:HardwareInfoText -match $DDR4pattern -or $global:HardwareInfoText -match $DDR5pattern `
         -or $global:HardwareInfoText -match $DualChannelPattern -or $global:HardwareInfoText -match $TripleChannelPattern `
         -or $global:HardwareInfoText -match $QuadChannelPattern ) {


### PR DESCRIPTION
CPU-Z reports 2 x 32-bit channels for AM5 platforms when Dual-Channel memory is enabled. This is incorrect as one stick of DDR5 has 2 x 32-bit channels. However, in CPU-Z, on AM5, 2 x 32-bit channels does indeed mean dual-channel memory is working as intended and it is **not** one stick of DDR5.