### PR TITLE
Add disk tests

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -1651,7 +1651,7 @@ Function Test-SSDFreeSpace
     $GameVolume = Get-Volume -DriveLetter (Split-Path $script:AppInstallPath -Qualifier).TrimEnd(":")
 	$GamePhysicalDisk = $GameVolume | Get-Partition | Get-Disk | Get-PhysicalDisk
     $GameVolumeFreeSpace = ($GameVolume.SizeRemaining / $GameVolume.Size) * 100
-    $script:Tests.SSDFreeSpace.TestPassed = ($GameVolumeFreeSpace -le 75 -and $GamePhysicalDisk.MediaType -ne "SSD")
+    $script:Tests.SSDFreeSpace.TestPassed = ($GameVolumeFreeSpace -le 25 -and $GamePhysicalDisk.MediaType -ne "SSD")
 }
 Function Test-FreeDiskSpace
 {
@@ -2251,5 +2251,6 @@ Get-IsProcessRunning $HelldiversProcess
 $script:InstalledProgramsList = Get-InstalledPrograms
 Write-Host "Building menu... $([Environment]::NewLine)$([Environment]::NewLine)"
 Menu
+
 
 


### PR DESCRIPTION
Adds 4 new tests, all related to disks. These tests are:

1. SSD overfill (Warn if SSD is >75% full)
2. Free disk space check (Fail if <150GB free)
3. USB disk check (Fail if game drive bus type is USB)
4. Faster drive check (Info if a faster disk type is available (Compares drive and bus type))