### PR TITLE
Implement more resillient library and game data detection

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -2988,17 +2988,14 @@ Function Parse-VDF {
     )
 
     $root  = @{}
-    $stack = New-Object System.Collections.Stack
+    $stack = [System.Collections.Generic.Stack[hashtable]]::new()
     $stack.Push($root)
     $pendingKey = $null
 
-    $regex = [regex] '\"((?:\\.|[^""\\])*)\"|[{}]'
-    $matches = $regex.Matches($Content)
+    $regex = [regex]::new('"((?:\\.|[^"\\])*)"|[{}]', [Text.RegularExpressions.RegexOptions]::Compiled)
 
-    foreach ($m in $matches) {
-        $token = $m.Groups[0].Value
-
-        switch ($token) {
+    foreach ($m in $regex.Matches($Content)) {
+        switch ($m.Value) {
             '{' {
                 if ($pendingKey) {
                     $child = @{}


### PR DESCRIPTION
Replaces the per line regex searching of VDF and line specified parsing of ACF files with true VDF parsing that outputs nested hash tables. This method is more resilient and flexible than the previous scanning as well as being visually much tidier and easy to maintain, at least IMO