### PR TITLE
Fix bluetooth service toggle

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -2302,7 +2302,7 @@ Function AudioMenu
         @{
             Label  = "🔈 |B|luetooth Telephony Service"
             Hotkey = $null
-            Action = { RunAndPause { Switch-BluetoothTelephony } }
+            Action = { RunAndPause { Switch-BTAGService } }
         }
 
         @{
@@ -2496,3 +2496,4 @@ Finally
 {
     $Host.UI.RawUI.CursorPosition = $script:menuEnd
 }
+


### PR DESCRIPTION
~~I made a dumb mistake when porting the menus over in #246 which broke the BTAG toggle option~~
Looks like `Switch-BTAGService` accidentally got flipped to `Switch-BluetoothTelephony` in eab9581 and went unnoticed. Flips them back to restore functionality