### PR TITLE
Stop Get-CPUZ overwriting $script:HellbombScriptDirectory

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -1010,11 +1010,11 @@ Function Get-CPUZ {
         $entry = $zip.Entries | Where-Object { $_.FullName -eq $targetFile }
         If ($entry) {
             # Extract the file manually using streams
-            $script:HellbombScriptDirectory = Join-Path -Path $extractTo -ChildPath $targetFile
-            If (Test-Path $script:HellbombScriptDirectory) {
-    			Remove-Item $script:HellbombScriptDirectory -Force
+            $cpuzExtractionPath = Join-Path -Path $extractTo -ChildPath $targetFile
+            If (Test-Path $cpuzExtractionPath) {
+    			Remove-Item $cpuzExtractionPath -Force
 			}
-			$fileStream = [System.IO.File]::Create($script:HellbombScriptDirectory)
+			$fileStream = [System.IO.File]::Create($cpuzExtractionPath)
             $entryStream = $entry.Open()
             $entryStream.CopyTo($fileStream)
             $fileStream.Close()


### PR DESCRIPTION
`Get-CPUZ` was overwriting the `$script:HellbombScriptDirectory` variable, appending `/cpuz_x64.exe`. In most paths this wasn't causing issues as the checks happened before the `Get-CPUZ` calls but if the file didn't already exist it would attempt to fetch the hash of `cpuz_x64.exe/cpuz_x64.exe` and crash out.

Fixes the issue by using a local variable for the checks performed inside `Get-CPUZ`