### PR TITLE
Make WiFi Test pause before exiting

### DIFF
--- a/Hellbomb Script.ps1
+++ b/Hellbomb Script.ps1
@@ -2766,7 +2766,7 @@ Function NetworkMenu
         @{
             Label  = "🛜 |W|i-Fi LAN Test"
             Hotkey = "W"
-            Action = { Test-Wifi }
+            Action = { RunAndPause { Test-Wifi }; }
 			OS = 'Windows'
         }
 


### PR DESCRIPTION
Fixes an issue where the WiFi test results were impossible to read as it would jump back to the menu immediately upon displaying results